### PR TITLE
docker-based example: small fixes

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ The resulting index is 2.03GiB in size, compared to 4.4GiB for the uncompressed 
 ## Running the demo
 - Launch the Docker container: `docker-compose up`
 - Index the pre-converted OCR volumes with `./index_google1000`
-- **Search!** `curl http://localhost:8983/solr/ocrtest/t/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text`
+- **Search!** `curl 'http://localhost:8983/solr/ocrtest/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text'`
 
 
 ## Converting the hOCR to the input format manually

--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ The resulting index is 2.03GiB in size, compared to 4.4GiB for the uncompressed 
 ## Running the demo
 - Launch the Docker container: `docker-compose up`
 - Index the pre-converted OCR volumes with `./index_google1000`
-- **Search!** `curl 'http://localhost:8983/solr/ocrtest/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text'`
+- **Search!** `curl http://localhost:8983/solr/ocrtest/t/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text`
 
 
 ## Converting the hOCR to the input format manually
@@ -26,7 +26,7 @@ The instructions above fetch an archive with the hOCRs from the dataset pre-conv
 
 - Obtain the dataset by downloading the individual books, ideally with a newer version of bash or zsh:
   ```sh
-  $ wget 'http://commondatastorage.googleapis.com/books/icdar2007/Volume_{0000..0999}.zip'
+  $ wget http://commondatastorage.googleapis.com/books/icdar2007/Volume_{0000..0999}.zip
   $ for zip in *.zip; do unzip $i; done
   ```
 - Convert the individual hOCR files to the format needed by the Solr configuration

--- a/example/index_google1000
+++ b/example/index_google1000
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+import sys
 import tarfile
 from pathlib import Path
 


### PR DESCRIPTION
Hi,

this PR introduce some fixes for the docker-based example:

* `sys` module is imported in the indexer script. (The `sys` module is later referenced by the `sys.argv` call). 

* search url (in `README.md`) is also fixed and the `curl` command is properly escaped now.

* `wget` range fix