### PR TITLE
docker-example: minor fixes pt. 2

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -17,7 +17,7 @@ The resulting index is 2.03GiB in size, compared to 4.4GiB for the uncompressed 
 ## Running the demo
 - Launch the Docker container: `docker-compose up`
 - Index the pre-converted OCR volumes with `./index_google1000`
-- **Search!** `curl http://localhost:8983/solr/ocrtest/t/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text`
+- **Search!** `curl 'http://localhost:8983/solr/ocrtest/select?q=ocr_text:harvard&ocr_hl=true&ocr_hl.fields=ocr_text'`
 
 
 ## Converting the hOCR to the input format manually
@@ -27,12 +27,12 @@ The instructions above fetch an archive with the hOCRs from the dataset pre-conv
 - Obtain the dataset by downloading the individual books, ideally with a newer version of bash or zsh:
   ```sh
   $ wget http://commondatastorage.googleapis.com/books/icdar2007/Volume_{0000..0999}.zip
-  $ for zip in *.zip; do unzip $i; done
+  $ for zip in *.zip; do unzip $zip; done
   ```
 - Convert the individual hOCR files to the format needed by the Solr configuration
   (`<word>☛p:<pageNo>,l:<lineNo>,n:<wordNo>,x:<xOffset>,y:<yOffset>,w:<width>,h:<height>`):
   ```sh
-  $ for hocr in Volume_*/hOCR.html; do ./hocr2solr $hocr > $(echo $hocr |sed 's/.html/.txt'); done
+  $ for hocr in Volume_*/hOCR.html; do ./hocr2solr $hocr > $(echo $hocr |sed 's/.html/.txt/'); done
   ```
 - Index the books by passing the directory with the `.txt`-files as the first parameter:
   ```sh


### PR DESCRIPTION
This PR introduces some fixes in the main `README.md` for the docker-example setup:

* correct search url is used
* iteration over zip files works
* unterminated sed command is fixed